### PR TITLE
Music queue maximum

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :nostrum,
-  token: System.fetch_env!("BOT_TOKEN")
+  token: System.get_env("BOT_TOKEN")
 
 config :cnmn, :router,
   prefix: System.get_env("BOT_PREFIX", "c-")

--- a/lib/cnmn/application.ex
+++ b/lib/cnmn/application.ex
@@ -8,11 +8,11 @@ defmodule CNMN.Application do
 
   def start(_type, _args) do
     children = [
-      # event consumer
-      CNMN.Consumer,
       # music state manager
       {CNMN.Music.Manager, %{}}
-    ]
+    ] ++ if Mix.env() != :test, do:
+      # event consumer
+      [CNMN.Consumer], else: []
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end

--- a/lib/cnmn/command/music.ex
+++ b/lib/cnmn/command/music.ex
@@ -61,18 +61,41 @@ defmodule CNMN.Command.Music do
     end
   end
 
-  # player queue string builder
-  defp queue_string(tracks, strings \\ [], count \\ 1)
+  @doc ~S"""
+  Parse a list of CNMN.Music.Track structs into a list.
 
-  defp queue_string([track | queue], strings, count) do
-    queue_string(queue, strings ++ ["**#{count}.** #{track.title}"], count + 1)
+  ## Examples
+
+      iex> CNMN.Command.Music.queue_string([%CNMN.Music.Track{title: "Test 1"}])
+      "**1.** Test 1"
+
+      iex> CNMN.Command.Music.queue_string([
+      ...>  %CNMN.Music.Track{title: "Test 1"},
+      ...>  %CNMN.Music.Track{title: "Test 2"}])
+      "**1.** Test 1\n**2.** Test 2"
+
+  Setting `max` will limit the max results.
+
+      iex> CNMN.Command.Music.queue_string([
+      ...>  %CNMN.Music.Track{title: "Test 1"},
+      ...>  %CNMN.Music.Track{title: "Test 2"},
+      ...>  %CNMN.Music.Track{title: "Test 3"},
+      ...>  %CNMN.Music.Track{title: "Test 4"},
+      ...>  %CNMN.Music.Track{title: "Test 5"}], [], 4)
+      "**1.** Test 1\n**2.** Test 2\n**3.** Test 3\n**4.** Test 4"
+
+  """
+  def queue_string(tracks, strings \\ [], max \\ 10, count \\ 1)
+
+  def queue_string([track | queue], strings, max, count) when count <= max do
+    queue_string(queue, strings ++ ["**#{count}.** #{track.title}"], max, count + 1)
   end
 
-  defp queue_string([], [], _count) do
+  def queue_string([], [], _max, _count) do
     "No items in queue"
   end
 
-  defp queue_string([], strings, _count) do
+  def queue_string(_tracks, strings, _max, _count) do
     Enum.join(strings, "\n")
   end
 
@@ -92,7 +115,7 @@ defmodule CNMN.Command.Music do
                 value: state.current.title
               },
               %Embed.Field{
-                name: "Queue",
+                name: "Queue (#{length(state.queue)} track(s))",
                 value: queue_string(state.queue)
               }
             ]

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,10 @@ defmodule CNMN.MixProject do
 
   def deps do
     [
-      {:nostrum, "~> 0.7.0-rc2"},
+      {:nostrum, "~> 0.7.0-rc2",
+        # nostrum should not run during tests
+        # (see https://github.com/Kraigie/nostrum/issues/230#issuecomment-789498187)
+        runtime: Mix.env() != :test},
       {:mogrify, "~> 0.9.2"},
       {:temp, "~> 0.4"},
       {:jason, "~> 1.3"}

--- a/test/command/music_test.exs
+++ b/test/command/music_test.exs
@@ -1,0 +1,4 @@
+defmodule CNMN.Command.MusicTest do
+  use ExUnit.Case, async: true
+  doctest CNMN.Command.Music
+end


### PR DESCRIPTION
- test scaffolding
- music queue now returns 10 results at most
